### PR TITLE
1. 修改signal_handler函数,用于SIGSEG/SIGILL/SIGFPE/SIGBUS的处理

### DIFF
--- a/src/network-mysqld.h
+++ b/src/network-mysqld.h
@@ -46,6 +46,8 @@
 
 #include <glib.h>
 
+#include <execinfo.h>
+
 #include "network-exports.h"
 
 #include "network-socket.h"
@@ -59,6 +61,8 @@
 #include "lua-registry-keys.h"
 #include "network-mysqld-stats.h"
 #include "network-conn-errcode.h"
+
+#define MAX_FRAMES 128
 
 #define SEND_ERR_MSG_HANDLE(log_func, errmsg, con)                              \
 do {                                                                            \


### PR DESCRIPTION
1.修改原来的signal处理逻辑，原来只有在设置invoke_dbg_on_crash的时候才会注册SIGSEG的信号处理，现在默认加上
2.将原来的基于gdb的backtrace方式调整成基于execinfo.h的backtrace/backtrace_symbols
