### PR TITLE
Don't close client when master backend is changed

### DIFF
--- a/src/network-mysqld-packet.c
+++ b/src/network-mysqld-packet.c
@@ -1194,7 +1194,7 @@ int network_mysqld_proto_get_ok_packet(network_packet *packet, network_mysqld_ok
 
     err = network_mysqld_proto_get_lenenc_int(packet, &affected);
     if (err != 0) {
-        msg = "get ok packet's insert_id failed";
+        msg = "get ok packet's affected_rows failed";
         goto funcexit;
     }
     err = network_mysqld_proto_get_lenenc_int(packet, &insert_id);


### PR DESCRIPTION
Don't close client,which is not in transaction and has no 'get_lock', when master backend is changed